### PR TITLE
Always compact hashes to create keys for memcached

### DIFF
--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -30,10 +30,7 @@ def hashRequest(request):
   normalizedParams = ','.join( sorted(queryParams) ) or 'noParam'
   myHash = stripControlChars(normalizedParams) #memcached doesn't like unprintable characters in its keys
 
-  if len(myHash) > 249: #memcached key size limitation
-    return compactHash(myHash)
-  else:
-    return myHash
+  return compactHash(myHash)
 
 
 def hashData(targets, startTime, endTime):
@@ -42,10 +39,8 @@ def hashData(targets, startTime, endTime):
   endTimeString = endTime.strftime("%Y%m%d_%H%M")
   myHash = targetsString + '@' + startTimeString + ':' + endTimeString
   myHash = stripControlChars(myHash)
-  if len(myHash) > 249:
-    return compactHash(myHash)
-  else:
-    return myHash
+
+  return compactHash(myHash)
 
 
 def stripControlChars(string):


### PR DESCRIPTION
Currently, the code compacts if the length of the request key is > 249.
The memcache max key length is 250, so this would appear to make sense.
Unfortunately, under the covers, django's memcached handling creates a
key by combining it "with the cache prefix and key version to provide
a final cache key".

See for more:
https://docs.djangoproject.com/en/dev/topics/cache/#cache-key-transformation
